### PR TITLE
Add tags option for Raven config

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ is useful for associating errors with releases in the Sentry interface.
 }
 ```
 
+##### tags   - optional
+
+A hash of tags to apply to each error event. This is useful for associating
+errors to specfic parts of your application and the ability to filter within
+the Sentry interface.
+
+```JS
+{
+	tags: {
+		appName: "o-errors"
+	}
+}
+```
+
 ##### logLevel     - optional
 
 Control the operation of the `oErrors.log`, `oErrors.warn` and `oErrors.error` API.

--- a/src/js/oErrors.js
+++ b/src/js/oErrors.js
@@ -127,6 +127,9 @@ Errors.prototype._configureAndInstallRaven = function(options, raven) {
 		ravenOptions.release = options.siteVersion;
 	}
 
+	if (options.tags) {
+		ravenOptions.tags = options.tags;
+	}
 
 	this.ravenClient.config(sentryEndpoint, ravenOptions);
 	this.ravenClient.install();

--- a/test/test_errors.js
+++ b/test/test_errors.js
@@ -37,6 +37,18 @@ describe("oErrors", function() {
 			expect(mockRavenClient.configOptions.release).to.equal("v1.0.0");
 		});
 
+		it("should configure the raven client with tags if the tags option is configured", function() {
+			new Errors().init({
+				tags: {
+					appName: "o-errors"
+				},
+				sentryEndpoint: "//app.getsentry.com/123"
+			}, mockRavenClient);
+
+			expect(mockRavenClient.configOptions.tags).to.be.an('object');
+			expect(mockRavenClient.configOptions.tags).to.include.keys('appName');
+		});
+
 		it("should configure the log level according the the logLevel option", function() {
 			var errors = new Errors().init({
 				sentryEndpoint: "//app.getsentry.com/123",


### PR DESCRIPTION
This simply allows a `tags` object to be supplied in the options and passed to the Raven configuration. Read more about Sentry tags [here](https://www.getsentry.com/docs/tags/).

This is a use-case within Next whereby all of our client-side errors across many apps are aggregated to one Sentry team [ft-next-frontend](https://app.getsentry.com/nextftcom/ft-next-frontend). Tagging will allow us to pass the application name and enable filtering within the Sentry interface and hopefully result in faster isolation of errors to specific applications.

/cc @samgiles 