### PR TITLE
Create a `filterError` configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,12 +136,16 @@ will not be reported. Defaults to `true`.
 
 ##### filterError - optional
 
-A `function` that can be used to filter errors that are reported.  The function
-should accept one argument.  This argument is an `object` that has two fields,
+A `function` that can be used to filter errors before they are reported.  The function
+should accept one argument, an `object` with two fields,
 an `error` field which contains the reported `error` and a `context` field,
 which contains any additional context.
 
-The function should return a boolean.
+The function should return a boolean inidicating whether the error should be
+sent or not, if `true` or coerced to a truthy value, the error will be sent,
+if `false` the error will be filtered.
+
+This function should not mutate the data object or its fields.
 
 Note: this may only be configured through the `init` method, it will report an
 `Error` and continue without filtering enabled if this is configured

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ if they occur _before_ initialisation, although any errors reported using the
 Configure `o-errors` using the `oErrors.init` method, or using a `<script>`
 tag (see [Using markup to configure `o-errors`](#using-markup-to-configure-oerrors)).
 
+Some options are only configurable when using the `init` method as they must accept
+a function.
+
 #### Available options
 
 ##### sentryEndpoint - required
@@ -128,6 +131,25 @@ will not be reported. Defaults to `true`.
 ```JS
 {
 	enabled: false
+}
+```
+
+##### filterError - optional
+
+A `function` that can be used to filter errors that are reported.  The function
+should accept one argument.  This argument is an `object` that has two fields,
+an `error` field which contains the reported `error` and a `context` field,
+which contains any additional context.
+
+The function should return a boolean.
+
+Note: this may only be configured through the `init` method, it will report an
+`Error` and continue without filtering enabled if this is configured
+declaratively.
+
+```JS
+{
+	filterError: function(data) { return true; }
 }
 ```
 

--- a/src/js/oErrors.js
+++ b/src/js/oErrors.js
@@ -371,17 +371,6 @@ Errors.prototype._getEventPath = function(event) {
 };
 
 /**
- * A hook to decide whether to send the data.
- *
- * @private
- * @param {Object} data - The data object from Raven
- * @returns {bool}
- */
-Errors.prototype._shouldSendError = function(data) {
-	return true;
-};
-
-/**
  * A hook to add additional data to the payload before sending.
  *
  * @private

--- a/src/js/oErrors.js
+++ b/src/js/oErrors.js
@@ -23,6 +23,8 @@ function Errors() {
 	// Cache the declarative config String to avoid reading the DOM more than
 	// once, once initialised, the reference to the string is released for GC.
 	this._declarativeConfigString = false;
+
+	this._filterError = function(error) { return true; };
 }
 
 /**
@@ -69,6 +71,22 @@ Errors.prototype.init = function(options, raven) {
 
 	if (hasDeclarativeConfig) {
 		options = this._initialiseDeclaratively(options);
+
+		if (options.filterError) {
+			options.filterError = undefined;
+
+			// So the error is surfaced, but only once the current context has
+			// completed so that oErrors can finish initialisation, trigger an error on the main event loop.
+			// This will also report it into Sentry as it Raven will have been
+			// installed and configured by the time the Error is thrown.
+			setTimeout(function oErrorsInitError() {
+				throw new Error("Can not configure 'oErrors' with `filterError` using declarative markup - error filtering will not be enabled");
+			}, 0);
+		}
+	}
+
+	if (typeof options.filterError === 'function') {
+		this._filterError = options.filterError;
 	}
 
 	// If errors is configured to be disabled, (options.disabled = true),
@@ -115,11 +133,9 @@ Errors.prototype._configureAndInstallRaven = function(options, raven) {
 	this.ravenClient = raven;
 
 	var sentryEndpoint = options.sentryEndpoint;
-	var shouldSendError = this._shouldSendError.bind(this);
 	var updatePayloadBeforeSend = this._updatePayloadBeforeSend.bind(this);
 
 	var ravenOptions = {
-		shouldSendCallback: shouldSendError,
 		dataCallback: updatePayloadBeforeSend
 	};
 
@@ -174,21 +190,26 @@ Errors.prototype._flushBufferedErrors = function() {
  * @return {Error} - The passed in error
  */
 Errors.prototype.report = function(error, context) {
+	var _context = context || {};
+	var reportObject = { error: error, context: _context };
+
 	if (!this.initialised) {
-		this._errorBuffer.push({ error: error, context: context });
+		this._errorBuffer.push(reportObject);
 		return error;
 	}
 
-	context = context || {};
+	if (!this._filterError(reportObject)) {
+		return error;
+	}
 
 	// Raven, for some reason completely ignores the contents of
 	// error.message... to get around this, we attach the error message to the
 	// context object.
 	if (error.message) {
-		context.errormessage = error.message;
+		_context.errormessage = error.message;
 	}
 
-	this.ravenClient.captureException(error, context);
+	this.ravenClient.captureException(error, _context);
 	return error;
 };
 

--- a/src/js/oErrors.js
+++ b/src/js/oErrors.js
@@ -75,10 +75,11 @@ Errors.prototype.init = function(options, raven) {
 		if (options.filterError) {
 			options.filterError = undefined;
 
-			// So the error is surfaced, but only once the current context has
-			// completed so that oErrors can finish initialisation, trigger an error on the main event loop.
-			// This will also report it into Sentry as it Raven will have been
-			// installed and configured by the time the Error is thrown.
+			// Throw the error on the main event loop rather than in this
+			// context so that the error can be surfaced to the developer
+			// without halting the current context.  The effect being that
+			// oErrors will continue to initialise and the error can still be
+			// triggered in the console and reported to the aggregator.
 			setTimeout(function oErrorsInitError() {
 				throw new Error("Can not configure 'oErrors' with `filterError` using declarative markup - error filtering will not be enabled");
 			}, 0);


### PR DESCRIPTION
Given the error and context, a product developer may wish to make a decision about whether to report the error to the aggregator.  This will allow a config option where you can specify a `filter` function that accepts a data `object` which has an `error` and `context` field:

```JS
{
  filterError: function(data) {
    var error = data.error;
    var context = data.context;
    return shouldSendError(error) && context.someValue;
  }
}
```