### PR TITLE
Stop using Chrome's event.path API.

### DIFF
--- a/src/js/oErrors.js
+++ b/src/js/oErrors.js
@@ -349,6 +349,11 @@ Errors.prototype.destroy = function() {
 };
 
 Errors.prototype.handleLogEvent = function(ev) {
+	// If no event is passed here, return early
+	if (!ev) {
+		return;
+	}
+
 	// Tag the context with additional information about the DOM.
 	var context = {
 		info: ev.detail.info || {},
@@ -384,8 +389,8 @@ Errors.prototype.handleLogEvent = function(ev) {
 Errors.prototype._getEventPath = function(event) {
 	var path = [];
 
-	// IE backwards compatibility (get the actual target). If not IE, uses
-	// `event.target`
+	// IE backwards compatibility (get the actual target). If IE, uses
+	// `window.event.srcElement`
 	var element = event.target || window.event.srcElement;
 
 	while (element) {

--- a/src/js/oErrors.js
+++ b/src/js/oErrors.js
@@ -355,6 +355,11 @@ Errors.prototype.handleLogEvent = function(ev) {
 		extra: {
 			"context:dom": this._getEventPath(ev).reduceRight(function(builder, el) {
 				var classList = Array.prototype.slice.call(el.classList || []);
+
+				if (!el.nodeName) {
+					return builder + " - " + el.constructor.name + "\n";
+				}
+
 				var nodeName = el.nodeName.toLowerCase();
 
 				if (nodeName.indexOf('#') === 0) {
@@ -377,19 +382,11 @@ Errors.prototype.handleLogEvent = function(ev) {
  * @returns {Array} - An array of Elements.
  */
 Errors.prototype._getEventPath = function(event) {
-
-	// event.path is available in some browsers, most notable Chrome
-	if (event.path) {
-		// Array.prototype.slice.call coerces a NodeList to an array. Could
-		// use Array.from but it is not in the Polyfill service default set.
-		return Array.prototype.slice.call(event.path);
-	}
-
 	var path = [];
 
 	// IE backwards compatibility (get the actual target). If not IE, uses
 	// `event.target`
-	var element = window.event ? window.event.srcElement : event.target;
+	var element = event.target || window.event.srcElement;
 
 	while (element) {
 		path.push(element);

--- a/test/test_errors.js
+++ b/test/test_errors.js
@@ -237,7 +237,7 @@ describe("oErrors", function() {
 				expect(path[0]).to.be(firstLevelDiv);
 				expect(path[1]).to.be(topLevelDiv);
 				expect(path[2]).to.be(document.body);
-				expect(path[3]).to.be(document.body.parentElement);
+				expect(path[3]).to.be(document.documentElement);
 				expect(path[4]).to.be(undefined);
 
 				done();

--- a/test/test_errors.js
+++ b/test/test_errors.js
@@ -236,6 +236,9 @@ describe("oErrors", function() {
 				var path = errors._getEventPath(ev);
 				expect(path[0]).to.be(firstLevelDiv);
 				expect(path[1]).to.be(topLevelDiv);
+				expect(path[2]).to.be(document.body);
+				expect(path[3]).to.be(document.body.parentElement);
+				expect(path[4]).to.be(undefined);
 
 				done();
 			}


### PR DESCRIPTION
I haven't included `window` in the `_getEventPath` for `o-errors` specifically because `o-errors` knows that the event is always handled on `document` (this is specifically for `oErrors.log`).  Window shouldn't have anything to do with it really - this is going to be different for `o-tracking`.

I've also made the IE8 fallback a little less clunky and put a safeguard in, just in case a non-`Node` makes it into the `Event` path for whatever reason.