### PR TITLE
Add init option to pass an existing errorBuffer array

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,30 @@ declaratively.
 }
 ```
 
+##### errorBuffer - optional
+
+An additional `array` of error objects which will be pushed into the internal
+buffer queue to be sent on initialisation. This can be useful if you have 
+caught errors inline on your page before oErrors.init() has been ran.  
+Each error in the array should be an `object` with two fields: an `error` field 
+which contains the reported `Error`, and a `context` field, which contains any
+additional reported context.
+
+Note: this may only be configured through the `init` method.
+
+```JS
+{
+	errorBuffer: [
+		{
+			error: new Error(),
+			context: {
+				additional: "info"
+			}
+		}
+	]
+}
+```
+
 #### Using markup to configure oErrors
 
 Include a `<script>` tag containing 'JSON' describing the configuration

--- a/origami.json
+++ b/origami.json
@@ -10,5 +10,8 @@
             "expanded": false,
             "description": "Declarative error tracking"
         }
-    ]
+    ],
+	"browserFeatures": {
+		"required": ["Array.isArray"]
+	}
 }

--- a/src/js/oErrors.js
+++ b/src/js/oErrors.js
@@ -4,10 +4,6 @@ function isFunction(fn) {
 	return typeof fn === 'function';
 }
 
-function isArray(arr) {
-	return Object.prototype.toString.call(arr) === '[object Array]';
-}
-
 function throwLater(error) {
 	// Throw the error on the main event loop rather than in this
 	// context so that the error can be surfaced to the developer
@@ -109,7 +105,7 @@ Errors.prototype.init = function(options, raven) {
 		this._filterError = options.filterError;
 	}
 
-	if (isArray(options.errorBuffer) && options.errorBuffer.length > 0) {
+	if (Array.isArray(options.errorBuffer) && options.errorBuffer.length > 0) {
 		this._errorBuffer = this._errorBuffer.concat(options.errorBuffer);
 	}
 

--- a/src/js/oErrors.js
+++ b/src/js/oErrors.js
@@ -4,6 +4,10 @@ function isFunction(fn) {
 	return typeof fn === 'function';
 }
 
+function isArray(arr) {
+	return Object.prototype.toString.call(arr) === '[object Array]';
+}
+
 function throwLater(error) {
 	// Throw the error on the main event loop rather than in this
 	// context so that the error can be surfaced to the developer
@@ -60,6 +64,7 @@ function Errors() {
  * @param options.siteVersion    {String}  - Optional, optionally the version of the code the page is running. This tags each error with the code version
  * @param options.logLevel       {String}  - Optional, see {@link Logger.level} for valid names
  * @param options.disabled       {Boolean} - Optional, If `true`, disable o-errors reporting.
+ * @param options.buffer         {Array}   - Optional, pre-existing buffer of error events to flush.
  * @param raven   {Object}   - The Raven JS client object.
  * @returns {Errors}
  */
@@ -102,6 +107,10 @@ Errors.prototype.init = function(options, raven) {
 
 	if (isFunction(options.filterError)) {
 		this._filterError = options.filterError;
+	}
+
+	if (isArray(options.errorBuffer) && options.errorBuffer.length > 0) {
+		this._errorBuffer = this._errorBuffer.concat(options.errorBuffer);
 	}
 
 	// If errors is configured to be disabled, (options.disabled = true),

--- a/test/test_errors.js
+++ b/test/test_errors.js
@@ -148,6 +148,22 @@ describe("oErrors", function() {
 			expect(mockRavenClient.lastCaptureMessageArgs[1].test).to.be("world");
 		});
 
+		it("should accept an Array of existing error events that can be used add to the internal error buffer", function(done) {
+			mockRavenClient.captureException = function(error, context) {
+				expect(error).to.be.an(Error);
+				expect(error.message).to.be("My test error");
+				expect(context).to.be.an('object');
+				done();
+			};
+
+			new Errors().init({
+				sentryEndpoint: "//123@app.getsentry.com/123",
+				logLevel: "contextonly",
+				enabled: true,
+				errorBuffer: [{ error: new Error("My test error")}]
+			}, mockRavenClient);
+		});
+
 		it("should still report the error and context if the tranformError function does not return a value", function() {
 			const errors = new Errors().init({
 				sentryEndpoint: "//123@app.getsentry.com/123",


### PR DESCRIPTION
On a rare occasion, one may have caught some errors inline within their page which they will want to beacon back to Sentry via oErrors. 

Currently we have the internal `this._errorBuffer[]` which catches any errors in between calling `new oError` and `oError.init()`. This PR simply adds a new option `errorBuffer` to the init `options` hash which concats the passed array to the internal buffer to be flushed along with the existing ones.

#### Use case:
On next.ft.com we have some HTTP/2 related connection errors which are preventing our main CSS from loading. We want to bind to `onError` of the `<link>` element and beacon those events back to Sentry to determine how often this is happening. 

As the CSS is (quite rightly) very high up the `<head>` we have not yet instantiated oErrors and thus the need to capture the event separately and pass to oErrors when `init`'ing 

/cc @AlbertoElias @matthew-andrews 