### PR TITLE
Correctly pass transformed error and context

### DIFF
--- a/src/js/oErrors.js
+++ b/src/js/oErrors.js
@@ -219,7 +219,7 @@ Errors.prototype.report = function(error, context) {
 	const _context = context || {};
 	let reportObject = { error: error, context: _context };
 
-		if (!this.initialised) {
+	if (!this.initialised) {
 		this._errorBuffer.push(reportObject);
 		return error;
 	}
@@ -244,11 +244,11 @@ Errors.prototype.report = function(error, context) {
 	// Raven, for some reason completely ignores the contents of
 	// error.message... to get around this, we attach the error message to the
 	// context object.
-	if (error.message) {
-		_context.errormessage = error.message;
+	if (reportObject.error.message) {
+		reportObject.context.errormessage = reportObject.error.message;
 	}
 
-	this.ravenClient.captureException(error, _context);
+	this.ravenClient.captureException(reportObject.error, reportObject.context);
 	return error;
 };
 

--- a/test/test_errors.js
+++ b/test/test_errors.js
@@ -170,6 +170,21 @@ describe("oErrors", function() {
 			expect(mockRavenClient.lastCaptureMessageArgs[1].test).to.be("world");
 		});
 
+		it("should return the orignal error when transform error does not return an error object", function() {
+			const errors = new Errors().init({
+				sentryEndpoint: "//123@app.getsentry.com/123",
+				logLevel: "contextonly",
+				enabled: true,
+				transformError: function() {
+					// Return malformed error object
+					return {};
+				}
+			}, mockRavenClient);
+
+			errors.report({ message: "Something failed" });
+			expect(mockRavenClient.lastCaptureMessageArgs[0].message).to.equal('Something failed');
+		});
+
 		it("should accept an Array of existing error events that will be added to the internal error buffer", function(done) {
 			mockRavenClient.captureException = function(error, context) {
 				expect(error).to.be.an(Error);


### PR DESCRIPTION
cc @AlbertoElias @pornel 