### PR TITLE
support filtering global errors

### DIFF
--- a/src/js/oErrors.js
+++ b/src/js/oErrors.js
@@ -185,6 +185,10 @@ Errors.prototype._configureAndInstallRaven = function(options, raven) {
 		ravenOptions.tags = options.tags;
 	}
 
+	if (isFunction(options.filterError)) {
+		ravenOptions.shouldSendCallback = options.filterError;
+	}
+
 	if (isFunction(options.transportFunction)) {
 		ravenOptions.transport = options.transportFunction;
 	}


### PR DESCRIPTION
See docs here https://docs.sentry.io/clients/javascript/tips/#sampling-data

The previous implementation (which can potentially be dropped now) only prevented explicitly reported errors from being sent. This approach, however, also applies to global errors that raven catches.

Not exactly sure what to do about tests. The test suite as a whole does not cover catching global errors, but addressing that should perhaps be another issue