### PR TITLE
Dont send window.FT errors to sentry

### DIFF
--- a/src/js/oErrors.js
+++ b/src/js/oErrors.js
@@ -254,6 +254,10 @@ Errors.prototype.report = function(error, context) {
 		return error;
 	}
 
+	if(error.toString().search("window.FT") > 0) {
+		return error;
+	}
+
 	const transformedError = this._transformError(reportObject);
 
 	// The _transformError may return a bad value, in order to protect against

--- a/test/test_errors.js
+++ b/test/test_errors.js
@@ -297,6 +297,20 @@ describe("oErrors", function() {
 			const error = errors.report(new Error("Test"));
 			proclaim.equal(error.message, "Test");
 		});
+
+		it("should not log an error to sentry if it finds window.FT in the message", function() {
+			mockRavenClient.captureException = function() {
+				throw new Error("Errors related to window.FT should not be sent to sentry");
+			};
+
+			errors.init({
+				sentryEndpoint: "http://app.getsentry.com/123",
+			}, mockRavenClient);
+
+
+			errors.report(new Error("Error in window.FT"));
+
+		});
 	});
 
 	describe("#_getEventPath(ev)", function() {


### PR DESCRIPTION
WTF...you may be wondering. There are a shit ton of errors related to window.FT being logged to sentry. Rhys did some work to try and filter these out through the `filterError` function but it's not working for some reason. So we're trying to force these not to be sent to sentry this way. The errors are always to do with scripts not loading properly over the network in some cases, and other scripts trying to reference that global variable. It's not pretty, so If you have any suggestions for other ways to fix this, do tell!