### PR TITLE
Stop using magic webpack imports

### DIFF
--- a/test/test_errors.test.js
+++ b/test/test_errors.test.js
@@ -1,8 +1,7 @@
 /* eslint-env mocha */
+/* global proclaim */
 
 import Errors from '../src/js/oErrors';
-
-import proclaim from 'proclaim';
 
 describe("oErrors", function() {
 	let mockRavenClient = null;


### PR DESCRIPTION
Stop using the magic imports for proclaim and sinon and pull them from the global because that's where Karma has added them. This is required for obt v10 to be released.