### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/demos/src/demo.js
+++ b/demos/src/demo.js
@@ -1,4 +1,4 @@
-import oErrors from '../../main';
+import oErrors from '../../main.js';
 
 document.addEventListener("DOMContentLoaded", function() {
 	document.dispatchEvent(new CustomEvent("o.DOMContentLoaded"));

--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@
  * @module oErrors
  * @see Errors
  */
-import Errors from './src/js/oErrors';
+import Errors from './src/js/oErrors.js';
 
 const errors = new Errors();
 

--- a/src/js/oErrors.js
+++ b/src/js/oErrors.js
@@ -1,5 +1,5 @@
 import Raven from 'raven-js';
-import Logger from './logger';
+import Logger from './logger.js';
 
 function isFunction(fn) {
 	return typeof fn === 'function';

--- a/test/test_errors.test.js
+++ b/test/test_errors.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim */
 
-import Errors from '../src/js/oErrors';
+import Errors from '../src/js/oErrors.js';
 
 describe("oErrors", function() {
 	let mockRavenClient = null;


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing