### PR TITLE
Log errors when logLevel set to consoleonly

### DIFF
--- a/src/js/oErrors.js
+++ b/src/js/oErrors.js
@@ -141,9 +141,11 @@ Errors.prototype.init = function(options, raven) {
 	if (Logger.level[logLevel] !== Logger.level.consoleonly) {
 		this._configureAndInstallRaven(options, raven);
 	} else {
+		const logger = this.logger;
 		this.ravenClient = {
-			// eslint-disable-next-line no-empty-function
-			captureException: function(){},
+			captureException: function() {
+				return logger.error(arguments);
+			},
 			// eslint-disable-next-line no-empty-function
 			uninstall: function(){}
 		};

--- a/test/test_errors.test.js
+++ b/test/test_errors.test.js
@@ -1,5 +1,5 @@
 /* eslint-env mocha */
-/* global proclaim */
+/* global proclaim, sinon */
 
 import Errors from '../src/js/oErrors.js';
 
@@ -95,7 +95,7 @@ describe("oErrors", function() {
 				logLevel: "consoleonly"
 			}, mockRavenClient);
 
-			const loggerProto = Object.getPrototypeOf(errors.logger)
+			const loggerProto = Object.getPrototypeOf(errors.logger);
 			sinon.spy(loggerProto, "error");
 
 			errors.report({ message: "Something failed" });

--- a/test/test_errors.test.js
+++ b/test/test_errors.test.js
@@ -89,6 +89,24 @@ describe("oErrors", function() {
 			proclaim.isUndefined(mockRavenClient.lastCaptureMessageArgs[0]);
 		});
 
+		it("should log messages if configured to the consoleonly log level", function() {
+			const errors = new Errors().init({
+				sentryEndpoint: "//app.getsentry.com/123",
+				logLevel: "consoleonly"
+			}, mockRavenClient);
+
+			const loggerProto = Object.getPrototypeOf(errors.logger)
+			sinon.spy(loggerProto, "error");
+
+			errors.report({ message: "Something failed" });
+			// in this case oErrors will pass the logger.error method
+			// the error and context using the arguments keyword, so
+			// args will be a nested array
+			proclaim.deepEqual(loggerProto.error.getCall(0).args[0][0], { message: "Something failed" });
+
+			loggerProto.error.restore();
+		});
+
 		it("should configure itself from the DOM if no options are present", function() {
 			const sentryConfiguration = document.createElement("script");
 			sentryConfiguration.type = "application/json";


### PR DESCRIPTION
Implements #110. When `logLevel` is set to `consoleonly`, logs any captured exceptions instead of doing nothing.